### PR TITLE
fix: sitemaps should not use subdirectory

### DIFF
--- a/sitemaps/sitemap-index.xml
+++ b/sitemaps/sitemap-index.xml
@@ -1,1 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://crossbell.io/sitemaps/sitemap-0.xml</loc></sitemap></sitemapindex>
+<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>https://crossbell.io/sitemap-0.xml</loc></sitemap></sitemapindex>

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ async function main() {
 		hostname: "https://crossbell.io",
 		destinationDir: path.resolve(__dirname, "..", "sitemaps"),
 		sourceData: handleUrls,
-		publicBasePath: "/sitemaps",
+		publicBasePath: "/",
 		gzip: false,
 	});
 }


### PR DESCRIPTION
https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap#general-guidelines

See also Crossbell-Box/crossbell.io#75